### PR TITLE
Barfiのデモコードを追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,19 @@
 import streamlit as st
+from barfi import st_barfi, Block
 
-st.write('Hello World')
+
+def main():
+  st.header('Node Based Notion Editor', divider='rainbow')
+
+  page = Block(name='Page')
+  page.add_input(name='parent')
+  page.add_output(name='child')
+
+  db = Block(name='DB')
+  db.add_input(name='parent')
+
+  st_barfi(base_blocks=[page, db])
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
関連するissue

- https://github.com/katayama-yuta/nbne/issues/5
- https://github.com/katayama-yuta/nbne/issues/6

少し触った所感として、barfiの現行バージョンでは以下が難しそうに感じた

- ノードレベルで持っているコネクションとNotion DBのプロパティレベルで持っているコネクションを分けて表現する
- Notion DBのプロパティはノードごとに可変で持たせる

barfiのフロント側は[baklava.js](https://github.com/newcat/baklavajs)がベースとなっているが、
代替ライブラリやライブラリ側の追加開発が必要そうか別途調査したい